### PR TITLE
Make it Python3 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ VERSION = '0.1.1'
 
 INSTALL_DEPS = [
     'enum34>=1.1.2',
+    'future>=0.16.0',
     'requests>=2.9.1'
 ]
 

--- a/test/ca_test.py
+++ b/test/ca_test.py
@@ -1,4 +1,5 @@
 """Unit tests for the ca module."""
+from __future__ import unicode_literals
 
 import unittest
 import mock

--- a/test/cert_test.py
+++ b/test/cert_test.py
@@ -1,4 +1,5 @@
 """Unit tests for the cert module."""
+from __future__ import unicode_literals
 
 import unittest
 

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -1,4 +1,5 @@
 """Unit tests for the tiny_cert module."""
+from __future__ import unicode_literals
 
 import unittest
 

--- a/tinycert/__init__.py
+++ b/tinycert/__init__.py
@@ -1,4 +1,5 @@
 """TinyCert v1 API wrapper"""
+from __future__ import unicode_literals
 
 from .session import Session, NoSessionException, auto_session
 from .cert import CertificateApi, State

--- a/tinycert/ca.py
+++ b/tinycert/ca.py
@@ -1,4 +1,7 @@
 """TinyCert Certificate Authority APIs"""
+from __future__ import unicode_literals
+
+from builtins import object
 
 
 class CertificateAuthorityApi(object):

--- a/tinycert/cert.py
+++ b/tinycert/cert.py
@@ -1,5 +1,7 @@
 """TinyCert Certificate APIs"""
+from __future__ import unicode_literals
 
+from builtins import object
 from enum import Enum
 
 


### PR DESCRIPTION
Those are the changes generated after running:
`futurize --stage1 -w **/*.py`
`futurize --stage2 -w --unicode-literals **/*.py`

Plus:
  - `hmac.new()` expects `key` to be `bytes`
  - `hmac.HMAC.update()` expects `msg` to be `bytes`

Signed-off-by: Marian.Rusu <rusumarian91@gmail.com>